### PR TITLE
Feature/basic authorization using roles

### DIFF
--- a/src/main/java/com/albert/Spring/Security/config/SecurityConfiguration.java
+++ b/src/main/java/com/albert/Spring/Security/config/SecurityConfiguration.java
@@ -1,0 +1,35 @@
+package com.albert.Spring.Security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+    @Bean
+    PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(){
+        UserDetails userDetailsOne = User.withUsername("User1")
+                .password(passwordEncoder().encode("pass1")).build();
+        UserDetails userDetailsTwo = User.withUsername("User2")
+                .password(passwordEncoder().encode("pass2")).build();
+        UserDetails admin = User.withUsername("admin")
+                .password(passwordEncoder().encode("admin1")).build();
+        return new InMemoryUserDetailsManager(admin,userDetailsOne,userDetailsTwo);
+    }
+
+ 
+}

--- a/src/main/java/com/albert/Spring/Security/config/SecurityConfiguration.java
+++ b/src/main/java/com/albert/Spring/Security/config/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package com.albert.Spring.Security.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -16,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfiguration {
     @Bean
     PasswordEncoder passwordEncoder(){
@@ -25,11 +27,11 @@ public class SecurityConfiguration {
     @Bean
     public UserDetailsService userDetailsService(){
         UserDetails userDetailsOne = User.withUsername("User1")
-                .password(passwordEncoder().encode("pass1")).build();
+                .password(passwordEncoder().encode("pass1")).roles("USER").build();
         UserDetails userDetailsTwo = User.withUsername("User2")
-                .password(passwordEncoder().encode("pass2")).build();
+                .password(passwordEncoder().encode("pass2")).roles("USER").build();
         UserDetails admin = User.withUsername("admin")
-                .password(passwordEncoder().encode("admin1")).build();
+                .password(passwordEncoder().encode("admin1")).roles("ADMIN").build();
         return new InMemoryUserDetailsManager(admin,userDetailsOne,userDetailsTwo);
     }
 

--- a/src/main/java/com/albert/Spring/Security/config/SecurityConfiguration.java
+++ b/src/main/java/com/albert/Spring/Security/config/SecurityConfiguration.java
@@ -2,8 +2,10 @@ package com.albert.Spring.Security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -31,5 +33,15 @@ public class SecurityConfiguration {
         return new InMemoryUserDetailsManager(admin,userDetailsOne,userDetailsTwo);
     }
 
- 
+    @Bean
+    public  SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf(csrfCustomizer->csrfCustomizer.disable());
+        httpSecurity.authorizeHttpRequests(request ->
+                request.requestMatchers("/api/v1/demo/home").permitAll()
+                        .anyRequest().authenticated());
+        httpSecurity.httpBasic(Customizer.withDefaults());
+        httpSecurity.sessionManagement(session->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return httpSecurity.build();
+    }
 }

--- a/src/main/java/com/albert/Spring/Security/controller/DemoController.java
+++ b/src/main/java/com/albert/Spring/Security/controller/DemoController.java
@@ -1,6 +1,7 @@
 package com.albert.Spring.Security.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,11 +16,13 @@ public class DemoController {
     }
 
     @GetMapping("/admin")
+    @PreAuthorize("hasRole('ADMIN')")
     public String admin(){
         return "This is an admin API";
     }
 
     @GetMapping("/user")
+    @PreAuthorize("hasRole('USER')")
     public String user(){
         return "This is a user API";
     }

--- a/src/main/java/com/albert/Spring/Security/controller/DemoController.java
+++ b/src/main/java/com/albert/Spring/Security/controller/DemoController.java
@@ -10,7 +10,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class DemoController {
 
     @GetMapping("/")
-    public String hello(){
-        return "Hello World";
+    public String home(){
+        return "This is a public API";
+    }
+
+    @GetMapping("/admin")
+    public String admin(){
+        return "This is an admin API";
+    }
+
+    @GetMapping("/user")
+    public String user(){
+        return "This is a user API";
     }
 }

--- a/src/main/java/com/albert/Spring/Security/controller/DemoController.java
+++ b/src/main/java/com/albert/Spring/Security/controller/DemoController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/demo")
 public class DemoController {
 
-    @GetMapping("/")
+    @GetMapping("/home")
     public String home(){
         return "This is a public API";
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=Spring-Security
 
-#for credentials for use as default besides getting a password in terminal
-spring.security.user.name=${user_username}
-spring.security.user.password=${user_password}
+##for credentials for use as default besides getting a password in terminal
+#spring.security.user.name=${user_username}
+#spring.security.user.password=${user_password}


### PR DESCRIPTION
Implemented Role based authorization for user and admin. The credentials are still coming from InMemory.

Basic Auth with In-Memory user details specified in the config file and Authorization globally of certain endpoints for example the public is authorized to access the /api/v1/demo/home endpoints while other required authentication.